### PR TITLE
Add rel=noopener to button link

### DIFF
--- a/src/smartbanner.js
+++ b/src/smartbanner.js
@@ -126,7 +126,7 @@ export default class SmartBanner {
           <div class="smartbanner__info__price">${this.options.price}${this.priceSuffix}</div>
         </div>
       </div>
-      <a href="${this.buttonUrl}" target="_blank" class="smartbanner__button"><span class="smartbanner__button__label">${this.options.button}</span></a>
+      <a href="${this.buttonUrl}" target="_blank" class="smartbanner__button"><span class="smartbanner__button__label" rel="noopener">${this.options.button}</span></a>
     </div>`;
   }
 


### PR DESCRIPTION
- [External Anchors should use `rel="noopener"`](https://developers.google.com/web/tools/lighthouse/audits/noopener)

Best practice to have `rel="noopener"` set to prevent XSS.